### PR TITLE
feat: include normalizeDistance helper function in Similarity enum

### DIFF
--- a/src/main/java/io/gravitee/resource/ai/vector/store/api/Similarity.java
+++ b/src/main/java/io/gravitee/resource/ai/vector/store/api/Similarity.java
@@ -20,7 +20,13 @@ package io.gravitee.resource.ai.vector.store.api;
  * @author GraviteeSource Team
  */
 public enum Similarity {
-  EUCLIDEAN,
-  COSINE,
-  DOT,
+  EUCLIDEAN, COSINE, DOT;
+
+  public float normalizeDistance(float distance) {
+    if (Float.isNaN(distance) || Float.isInfinite(distance)) return 0f;
+    return switch (this) {
+      case EUCLIDEAN -> 2f / (2f + Math.max(0f, distance));
+      case COSINE, DOT -> (2f - (distance < 0f ? 0f : (Math.min(distance, 2f)))) / 2f;
+    };
+  }
 }


### PR DESCRIPTION
Add a normalizeDistance method to the Similarity enum to be consumed by classes extending `io.gravitee.resource.ai.vector.store.api` (Ie, the redis / aws / etc specific resources)